### PR TITLE
enhanced loading screen

### DIFF
--- a/src/routes/App.js
+++ b/src/routes/App.js
@@ -9,10 +9,46 @@ import Header from "../components/header/Header";
 function App() {
   const isDesktop = useMediaQuery({ query: querySizes["lg"] });
   useEffect(() => {
-    let loader = document.getElementById("siteLoadingScreen");
-    if (loader) {
-      loader.classList.add("hidden");
-    }
+    const hideLoader = () => {
+      const loader = document.getElementById("siteLoadingScreen");
+      if (loader) {
+        loader.classList.add("hidden");
+      }
+    };
+
+    const waitForImagesToLoad = () => {
+      const images = Array.from(
+        document.getElementById("root").getElementsByTagName("img")
+      ).filter((img) => img.loading !== "lazy");
+
+      if (images.length === 0) {
+        // No images, hide immediately after paint
+        requestAnimationFrame(() => {
+          requestAnimationFrame(hideLoader);
+        });
+        return;
+      }
+
+      const imagePromises = images.map((img) => {
+        if (img.complete) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+          img.addEventListener("load", resolve, { once: true });
+          img.addEventListener("error", resolve, { once: true });
+        });
+      });
+
+      Promise.all(imagePromises).then(() => {
+        // Double requestAnimationFrame ensures images are painted
+        requestAnimationFrame(() => {
+          requestAnimationFrame(hideLoader);
+        });
+      });
+    };
+
+    // Wait a tick for React to render child components with their images
+    requestAnimationFrame(waitForImagesToLoad);
   }, []);
   return (
     <div className={`App ${isDesktop ? " desktopBg comicViewerDesktop" : "mt-8"}`}>


### PR DESCRIPTION
The loading screen was disappearing before images were fully painted to the view. This fix should make sure the screen only hides when the images are loaded and won't "pop" into existence.